### PR TITLE
mempool geth fix

### DIFF
--- a/pythereum/dclasses.py
+++ b/pythereum/dclasses.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from dataclasses_json import dataclass_json, LetterCase, config
 from pythereum.common import HexStr
 from pythereum.exceptions import ERPCDecoderException, ERPCEncoderException
+from typing import Optional
 
 
 def hex_int_decoder(hex_string: str | None) -> int | None:
@@ -479,59 +480,82 @@ class TransactionFull:
     The full information on a transaction to be executed, including metadata with reference to its inclusion on chain
     """
 
-    block_hash: HexStr | None = field(
+    block_hash: Optional[HexStr] | None = field(
+        default=None,
         metadata=config(decoder=hex_decoder, encoder=hex_encoder)
     )
-    block_number: int | None = field(
+    block_number: Optional[int] | None = field(
+        default=None,
         metadata=config(decoder=hex_int_decoder, encoder=hex_int_encoder)
     )
-    from_address: HexStr | None = field(
+    from_address: Optional[HexStr] | None = field(
+        default=None,
         metadata=config(field_name="from", decoder=hex_decoder, encoder=hex_encoder)
     )
-    gas: int | None = field(
+    gas: Optional[int] | None = field(
+        default=None,
         metadata=config(decoder=hex_int_decoder, encoder=hex_int_encoder)
     )
-    gas_price: int | None = field(
+    gas_price: Optional[int] | None = field(
+        default=None,
         metadata=config(decoder=hex_int_decoder, encoder=hex_int_encoder)
     )
-    max_fee_per_gas: int | None = field(
+    max_fee_per_gas: Optional[int] | None = field(
+        default=None,
         metadata=config(decoder=hex_int_decoder, encoder=hex_int_encoder)
     )
-    max_priority_fee_per_gas: int | None = field(
+    max_priority_fee_per_gas: Optional[int] | None = field(
+        default=None,
         metadata=config(decoder=hex_int_decoder, encoder=hex_int_encoder)
     )
-    hash: HexStr | None = field(
+    hash: Optional[HexStr] | None = field(
+        default=None,
         metadata=config(decoder=hex_decoder, encoder=hex_encoder)
     )
-    input: HexStr | None = field(
+    input: Optional[HexStr] | None = field(
+        default=None,
         metadata=config(decoder=hex_decoder, encoder=hex_encoder)
     )
-    nonce: int | None = field(
+    nonce: Optional[int] | None = field(
+        default=None,
         metadata=config(decoder=hex_int_decoder, encoder=hex_int_encoder)
     )
-    to_address: HexStr | None = field(
+    to_address: Optional[HexStr] | None = field(
+        default=None,
         metadata=config(field_name="to", decoder=hex_decoder, encoder=hex_encoder)
     )
-    transaction_index: int | None = field(
+    transaction_index: Optional[int] | None = field(
+        default=None,
         metadata=config(decoder=hex_int_decoder, encoder=hex_int_encoder)
     )
-    value: int | None = field(
+    value: Optional[int] | None = field(
+        default=None,
         metadata=config(decoder=hex_int_decoder, encoder=hex_int_encoder)
     )
-    type: int | None = field(
+    type: Optional[int] | None = field(
+        default=None,
         metadata=config(decoder=hex_int_decoder, encoder=hex_int_encoder)
     )
-    access_list: list["Access"] | None = field(
-        metadata=config(decoder=access_list_decoder, encoder=access_list_encoder)
+    access_list: Optional[list["Access"] ]| None = field(
+        metadata=config(decoder=access_list_decoder, encoder=access_list_encoder),
+        default_factory=list
     )
-    chain_id: int | None = field(
+    chain_id: Optional[int] | None = field(
+        default=None,
         metadata=config(decoder=hex_int_decoder, encoder=hex_int_encoder)
     )
-    v: int | None = field(
+    v: Optional[int] | None = field(
+        default=None,
         metadata=config(decoder=hex_int_decoder, encoder=hex_int_encoder)
     )
-    r: HexStr | None = field(metadata=config(decoder=hex_decoder, encoder=hex_encoder))
-    s: HexStr | None = field(metadata=config(decoder=hex_decoder, encoder=hex_encoder))
+    r: Optional[HexStr] | None = field(
+        default=None,
+        metadata=config(decoder=hex_decoder, encoder=hex_encoder)
+        )
+    s: Optional[HexStr] | None = field(
+        default=None,
+        metadata=config(decoder=hex_decoder, encoder=hex_encoder)
+        )
 
 
 @dataclass_json(letter_case=LetterCase.CAMEL)

--- a/pythereum/socket_pool.py
+++ b/pythereum/socket_pool.py
@@ -14,12 +14,13 @@ class WebsocketPool:
     """
 
     def __init__(
-        self, url: str, pool_size: int = 6, connection_max_payload_size: int = 2**20
+        self, url: str, pool_size: int = 6, connection_max_payload_size: int = 2**20, connection_timeout: int = 20000
     ):
         self._url = url
         self._id = 0
         self._max_pool_size = pool_size
         self._max_payload_size = connection_max_payload_size
+        self._timeout = connection_timeout
         self._sockets_used = 0
         self._sockets = Queue(maxsize=pool_size)
         self.connected = False
@@ -34,7 +35,7 @@ class WebsocketPool:
         # Creates a number of sockets equal to the maximum pool size
         sockets = await gather(
             *(
-                connect(self._url, max_size=self._max_payload_size)
+                connect(self._url, max_size=self._max_payload_size, ping_interval=self._timeout)
                 for _ in range(self._max_pool_size)
             )
         )


### PR DESCRIPTION
adding the max_size to the payload worked but this brought other problems:

1- given that the amount of data to be received was large, the wss connection did not receive pings from the server, and after 20 seconds it timed out

solution: the connection_timeout parameter has been added to EthRPC, always 20 seconds by default, but can be changed as desired, also selecting "None"

2- the structure of the txpool_content call was quite complex, this gave an error 

```
async def get_mempool_geth(
        self, websocket: websockets.WebSocketClientProtocol | None = None
    ) -> TransactionFull | list[TransactionFull]:
        """
        Access the memory pool for a geth node, does not work on other node types
        Under testing, feel free to improve.
        """
        msg = await self._send_message("txpool_content", [], websocket)
        match msg:
            case None:
                return msg
            case dict():
                return TransactionFull.from_dict(msg)  <= ****** HERE ******
            case _:
                return [TransactionFull.from_dict(result) for result in msg]
```

when trying to insert data into the class

solution: data is collected and then inserted into the class

3- I noticed that some transactions were missing some parameters (sometimes "chainId" was missing, sometimes "maxGasPerFee" etc)

solution: I made the class parameters optional

now the function `get_mempool_geth()` works fine :) 